### PR TITLE
fix(core): update signals to v18 and move current external patchState to internal

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -10,7 +10,8 @@
       "enabled": true,
       "path": ".cache",
       "environment": "all"
-    }
+    },
+    "analytics": false
   },
   "projects": {
     "compass-goals-walkthrough": {

--- a/angular.json
+++ b/angular.json
@@ -10,8 +10,7 @@
       "enabled": true,
       "path": ".cache",
       "environment": "all"
-    },
-    "analytics": false
+    }
   },
   "projects": {
     "compass-goals-walkthrough": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@ngrx/signals": "^18.0.0-rc.2",
+        "@ngrx/signals": "^18.0.0",
         "core-js": "^3.37.1",
         "cross-fetch": "^4.0.0",
         "crypto-es": "^2.1.0",
@@ -5338,9 +5338,9 @@
       ]
     },
     "node_modules/@ngrx/signals": {
-      "version": "18.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-18.0.0-rc.2.tgz",
-      "integrity": "sha512-KFj0I5seMVVqqXaoBqeQiR/+dKho4n+Ry/RmaAfa3f0rgYhfaxNTo7U39B7udIYjJf8Z+eYPmBFJEU3HGQU0mA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-18.0.0.tgz",
+      "integrity": "sha512-zAWlsRqBbP/JsLmXHupfRb/BD5Xe2I03hLIB+q+vmXwAf29KCwRMVPLpWWu0DEgJvM0dVklP9WIgcG/D1pKScg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@ngrx/signals": "^18.0.0-rc.2",
+    "@ngrx/signals": "^18.0.0",
     "core-js": "^3.37.1",
     "cross-fetch": "^4.0.0",
     "crypto-es": "^2.1.0",

--- a/src/app/core/firebase/firebase.mock.service.ts
+++ b/src/app/core/firebase/firebase.mock.service.ts
@@ -6,8 +6,7 @@ import { environment } from '../../../environments/environment';
 import { DocumentSnapshot, serverTimestamp, Timestamp, getDoc, getDocs, doc, setDoc, updateDoc, deleteDoc, docData, collection, collectionData, collectionChanges, query, where, orderBy, OrderByDirection, limit, startAt, startAfter, endAt, endBefore, DocumentChange, increment, AggregateQuerySnapshot, AggregateField, AggregateSpec, getAggregateFromServer, getCountFromServer } from '@angular/fire/firestore';
 import { AnyEntity, QueryParams, QueryOptions } from '../store/app.model';
 import { DatabaseService } from './database.service';
-import { SelectEntityId, setAllEntities } from '@ngrx/signals/entities';
-import { patchState } from '@ngrx/signals';
+import { SelectEntityId } from '@ngrx/signals/entities';
 import { AuthMockDB } from '../store/auth/auth.mock';
 
 // Entity Model DB Data
@@ -49,15 +48,15 @@ export class FirebaseMockService implements DatabaseService {
     private injector: Injector,
   ) {
     // Init Entity Models
-    patchState(this.DB['weeklyGoalReflections'], setAllEntities(WEEKLYGOALREFLECTION_DB, { selectId }));
-    patchState(this.DB['quarterlyGoalReflections'], setAllEntities(QUARTERLYGOALREFLECTION_DB, { selectId }));
-    patchState(this.DB['longTermGoalReflections'], setAllEntities(LONGTERMGOALREFLECTION_DB, { selectId }));
-    patchState(this.DB['hashtags'], setAllEntities(HASHTAG_DB, { selectId }));
-    patchState(this.DB['longTermGoals'], setAllEntities(LONGTERMGOAL_DB, { selectId }));
-    patchState(this.DB['weeklyGoals'], setAllEntities(WEEKLYGOAL_DB, { selectId }));
-    patchState(this.DB['quarterlyGoals'], setAllEntities(QUARTERLYGOAL_DB, { selectId }));
-    patchState(this.DB['users'], setAllEntities(USER_DB, { selectId }));
-    patchState(this.DB['userContexts'], setAllEntities(USERCONTEXT_DB, { selectId }));
+    this.DB['weeklyGoalReflections'].init(WEEKLYGOALREFLECTION_DB);
+    this.DB['quarterlyGoalReflections'].init(QUARTERLYGOALREFLECTION_DB);
+    this.DB['longTermGoalReflections'].init(LONGTERMGOALREFLECTION_DB);
+    this.DB['users'].init(USER_DB);
+    this.DB['userContexts'].init(USERCONTEXT_DB);
+    this.DB['quarterlyGoals'].init(QUARTERLYGOAL_DB);
+    this.DB['weeklyGoals'].init(WEEKLYGOAL_DB);
+    this.DB['hashtags'].init(HASHTAG_DB);
+    this.DB['longTermGoals'].init(LONGTERMGOAL_DB);
   }
 
   /** Creates a unique id */

--- a/src/app/core/store/app.store.ts
+++ b/src/app/core/store/app.store.ts
@@ -1,7 +1,7 @@
 import { WritableSignal, inject } from '@angular/core';
 import { Timestamp, writeBatch } from '@angular/fire/firestore';
 import { patchState, signalStoreFeature, withMethods } from '@ngrx/signals';
-import { removeEntities, removeEntity, setEntities, setEntity, updateEntity, withEntities } from '@ngrx/signals/entities';
+import { removeEntities, removeEntity, setEntities, setEntity, updateEntity, withEntities, setAllEntities } from '@ngrx/signals/entities';
 import { EntityChanges, EntityId, SelectEntityId } from '@ngrx/signals/entities/src/models';
 import { CachedListenersService } from '../firebase/cached-listeners.service';
 import { DATABASE_SERVICE, DatabaseService } from '../firebase/database.service';
@@ -58,6 +58,9 @@ export function withEntitiesAndSelectMethods<S extends AnyEntity>() {
   return signalStoreFeature(
     withEntities<S>(),
     withMethods((store) => ({
+      init(entities: S[]) {
+        patchState(store, setAllEntities<S>(entities, { selectId }));
+      },
       selectEntity(id: string): S {
         const result = store.entityMap()[id];
 


### PR DESCRIPTION
Updates @ngrx/signals to v18 and changes mockDB store initialization logic from external to the store to an internal init method as per stores not being writeable by default in v18.